### PR TITLE
Refactor printDetails to getDetails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Creates a generic spell that can be cast.
 **description**: string, A short description of the spell.
 
 
-## printDetails()
-Print out all spell details and format it nicely.
-The format doesnt matter, as long as it contains the spell name, cost, and description.
+## getDetails()
+Returns a string of all of the spell's details.
+The format doesn't matter, as long as it contains the spell name, cost, and description.
 
 
 # DamageSpell(name, cost, damage, description)

--- a/constructors.js
+++ b/constructors.js
@@ -12,13 +12,11 @@
  */
 
   /**
-   * @method printDetails
-   * 
-   * Print out all spell details and format it nicely.
-   * The format doesnt matter, as long as it contains the spell name, cost, and description.
+   * Returns a string of all of the spell's details.
+   * The format doesn't matter, as long as it contains the spell name, cost, and description.
    *
-   * note: using comma separated arguments for console.log() will not satisfy the tests
-   * e.g. console.log(a, b, c); <-- no commas, please use string concatenation.
+   * @name getDetails
+   * @return {string} details containing all of the spells information.
    */
 
 /**
@@ -65,7 +63,7 @@
 
   /**
    * @method inflictDamage
-   * 
+   *
    * The spellcaster loses health equal to `damage`.
    * Health should never be negative.
    * If the spellcaster's health drops to 0,
@@ -76,7 +74,7 @@
 
   /**
    * @method spendMana
-   * 
+   *
    * Reduces the spellcaster's mana by `cost`.
    * Mana should only be reduced only if there is enough mana to spend.
    *
@@ -86,7 +84,7 @@
 
   /**
    * @method invoke
-   * 
+   *
    * Allows the spellcaster to cast spells.
    * The first parameter should either be a `Spell` or `DamageSpell`.
    * If it is a `DamageSpell`, the second parameter should be a `Spellcaster`.

--- a/test/test-script.js
+++ b/test/test-script.js
@@ -5,12 +5,10 @@ var sandbox;
 beforeEach(function() {
   // create a sandbox
   sandbox = sinon.sandbox.create();
-  sinon.spy(window.console, "log");
 });
 
 afterEach(function() {
   sandbox.restore();
-  console.log.restore();
 });
 
 describe('Spell', function() {
@@ -45,16 +43,14 @@ describe('Spell', function() {
       iceblast.description.should.equal('Creates a blast of ice, freezing any living thing where it stands.');
     });
 
-    it('should print out the all of the spell\'s information', function() {
+    it('should get a string containing all of the spell\'s information', function() {
       var fireball = new Spell('Fireball', 5, 'Conjures a ball of fire.');
-      fireball.printDetails();
-      var fireballDetails = console.log.getCall(0).args[0];
+      var fireballDetails = fireball.getDetails();
 
       expect(fireballDetails.match(/\b(Fireball|5|Conjures a ball of fire\.)/g).length).to.be.at.least(3);
 
       var iceBlast = new Spell('Ice Blast', 15, 'Creates a blast of ice, freezing any living thing where it stands.');
-      iceBlast.printDetails();
-      var iceBlastDetails = console.log.getCall(1).args[0];
+      var iceBlastDetails = iceBlast.getDetails();
 
       expect(iceBlastDetails.match(/\b(Ice Blast|15|Creates a blast of ice, freezing any living thing where it stands\.)/g).length).to.not.be.greaterThan(3);
     });


### PR DESCRIPTION
Testing `console.log` is actually very difficult since it can be called in a variety of ways:
```javascript
// Same results, impossible to enforce
console.log(foo + " " + bar + " " + baz);
console.log(foo, bar, baz);
console.log("%s %s %s", foo, bar, baz);
```
I changed the exercise to just return a string instead of requiring everyone to invoke `console.log` in a specific way.